### PR TITLE
[Feature][v1.1.0] Support Laravel 11, Logs improvements & maxProcessingTime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
             -   name: Setup PHP with coverage driver
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: ${{ matrix.version }}
+                    php-version: 8.2
                     coverage: pcov
 
             -   name: Start MySQL Database

--- a/.github/workflows/try-installation.yml
+++ b/.github/workflows/try-installation.yml
@@ -1,4 +1,4 @@
-name: Try Install Package (Laravel 10)
+name: Try Install Package (Laravel 10 & 11)
 env:
     LOCAL_ENV: ${{ secrets.LOCAL_ENV }}
 
@@ -7,13 +7,13 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                version: [ '^9.0', '^10.0' ]
+                version: [ '^10.0', '^11.0' ]
         runs-on: ubuntu-latest
         steps:
             -   name: Setup PHP with coverage driver
                 uses: shivammathur/setup-php@v2
                 with:
-                    php-version: 8.1
+                    php-version: 8.2
                     coverage: pcov
 
             -   name: Setup and install package on Laravel

--- a/README.md
+++ b/README.md
@@ -64,9 +64,11 @@ Run `composer test` 😆
 
 Available Tests:
 
-- Unit Testing
-- Integration Testing against MySQL & PostgreSQL for the `inbox:work` command
-- Human validation (lol)
+- Unit Testing 💪
+- Integration Testing against MySQL & PostgreSQL for the `inbox:work` command 😎
+- Human validation (lol) 🔥
+
+ShipSaaS loves tests, we won't ship sh!tty libraries 🌹
 
 ## Contributors
 - Seth Phat

--- a/README.md
+++ b/README.md
@@ -7,23 +7,33 @@
 <img src=".github/logo.png" width="200">
 </p>
 
-The inbox pattern is a popular design pattern that ensures:
+Talking about distributed computers & servers, it is quite normal nowadays to communicate between servers.
+
+Unlike a regular conversation though, there's no guarantee the message gets delivered only once, arrives in the right order, or even gets a "got it!" reply.
+
+Thus, we have **Inbox Pattern** to help us to achieve that.
+
+## What is the Inbox Pattern
+
+**The Inbox Pattern** is a popular design pattern in the microservice architecture that ensures:
 
 - High availability ✅
 - Guaranteed webhook deliverance, no msg lost ✅
 - Guaranteed **exactly-once/unique** webhook requests ✅
-- Execute webhook requests **in ORDER** ✅
+- Execute webhook requests **in ORDER/sequence** ✅
 - (Optional) High visibility & debug all prev requests ✅
 
-Laravel Inbox Process (powered by ShipSaaS) ships everything and 
+And with that being said:
+
+**Laravel Inbox Process (powered by ShipSaaS)** ships everything out-of-the-box and 
 helps you to roll out the inbox process in no time 😎🚀.
 
 ## Supports
 - Laravel 10+
 - PHP 8.2+
-- MySQL 8 and Postgres 13+
+- MySQL 8, MariaDB & Postgres 13+
 
-## Architecture
+## Architecture Diagram
 
 ![ShipSaaS - Laravel Inbox Process](./.github/arch.png)
 
@@ -46,7 +56,7 @@ php artisan migrate
 
 Visit: [ShipSaaS Inbox Documentation](https://inbox.shipsaas.tech)
 
-Best practices & notes are well documented too 😎!
+Best practices, usage & notes are well documented too 😎!
 
 ## Testing
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
-        "laravel/framework": "^10|dev-master",
+        "laravel/framework": "^10|^11|dev-master",
         "ext-pcntl": "*"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "shipsaas/laravel-inbox-process",
     "type": "library",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Inbox pattern process implementation for your Laravel Applications",
     "keywords": [
         "laravel library",

--- a/src/Commands/InboxWorkCommand.php
+++ b/src/Commands/InboxWorkCommand.php
@@ -47,6 +47,7 @@ class InboxWorkCommand extends Command
         $this->registerLifecycle($runningInboxRepo, $inboxMessageHandler, $lifecycle);
 
         $inboxMessageHandler->setTopic($this->topic);
+        $inboxMessageHandler->setHandleWriteLog($this->writeTraceLog(...));
         $this->runInboxProcess($inboxMessageHandler, $lifecycle);
 
         return 0;

--- a/src/Entities/InboxMessage.php
+++ b/src/Entities/InboxMessage.php
@@ -5,12 +5,14 @@ namespace ShipSaasInboxProcess\Entities;
 class InboxMessage
 {
     public int $id;
+    public string $externalId;
     public string $rawPayload;
 
     public static function make(object $rawDbRecord): InboxMessage
     {
         $inboxMsg = new InboxMessage();
         $inboxMsg->id = intval($rawDbRecord->id);
+        $inboxMsg->externalId = $rawDbRecord->externalId;
         $inboxMsg->rawPayload = $rawDbRecord->payload ?: '{}';
 
         return $inboxMsg;

--- a/src/Entities/InboxMessage.php
+++ b/src/Entities/InboxMessage.php
@@ -12,7 +12,7 @@ class InboxMessage
     {
         $inboxMsg = new InboxMessage();
         $inboxMsg->id = intval($rawDbRecord->id);
-        $inboxMsg->externalId = $rawDbRecord->externalId;
+        $inboxMsg->externalId = $rawDbRecord->external_id;
         $inboxMsg->rawPayload = $rawDbRecord->payload ?: '{}';
 
         return $inboxMsg;

--- a/src/Repositories/InboxMessageRepository.php
+++ b/src/Repositories/InboxMessageRepository.php
@@ -34,7 +34,7 @@ class InboxMessageRepository extends AbstractRepository
             ->where('topic', $topic)
             ->orderBy('created_at_unix_ms', 'ASC')
             ->limit($limit)
-            ->get(['id', 'payload'])
+            ->get(['id', 'external_id', 'payload'])
             ->map(InboxMessage::make(...));
     }
 

--- a/tests/Integration/Commands/InboxWorkCommandTest.php
+++ b/tests/Integration/Commands/InboxWorkCommandTest.php
@@ -54,6 +54,16 @@ class InboxWorkCommandTest extends TestCase
         // 4. validate
         $this->assertSame(0, $code);
         $this->assertStringContainsString('Processed 3 inbox messages', $result);
+
+        $this->assertStringContainsString('Handling message with externalId: "evt_1NWX0RBGIr5C5v4TpncL2sCf"', $result);
+        $this->assertStringContainsString('Handled message with externalId: "evt_1NWX0RBGIr5C5v4TpncL2sCf"', $result);
+
+        $this->assertStringContainsString('Handling message with externalId: "evt_1NWUFiBGIr5C5v4TptQhGyW3"', $result);
+        $this->assertStringContainsString('Handled message with externalId: "evt_1NWUFiBGIr5C5v4TptQhGyW3"', $result);
+
+        $this->assertStringContainsString('Handling message with externalId: "evt_1Nh2fp2eZvKYlo2CzbNockEM"', $result);
+        $this->assertStringContainsString('Handled message with externalId: "evt_1Nh2fp2eZvKYlo2CzbNockEM"', $result);
+
         $this->assertStringContainsString('[Info] No message found. Stopping...', $result);
 
         Event::assertDispatched(
@@ -134,6 +144,22 @@ class InboxWorkCommandTest extends TestCase
         $this->assertDatabaseMissing('running_inboxes', [
             'topic' => 'with_err_msg',
         ]);
+    }
+
+    public function testCommandStopsAfterAnAmountOfTime()
+    {
+        $beginAt = time();
+
+        $code = Artisan::call('inbox:work test --max-processing-time=10');
+        $result = Artisan::output();
+
+        $finishedAt = time();
+
+        $this->assertSame(0, $code);
+
+        $this->assertStringContainsString('[Info] Reached max processing time. Closing the process.', $result);
+
+        $this->assertGreaterThanOrEqual(10, $finishedAt - $beginAt);
     }
 }
 

--- a/tests/Unit/Entities/InboxMessageTest.php
+++ b/tests/Unit/Entities/InboxMessageTest.php
@@ -11,10 +11,12 @@ class InboxMessageTest extends TestCase
     {
         $inboxMsg = InboxMessage::make((object) [
             'id' => 1000,
+            'external_id' => 'fake-id',
             'payload' => '{"hello": "world"}',
         ]);
 
         $this->assertSame(1000, $inboxMsg->id);
+        $this->assertSame('fake-id', $inboxMsg->externalId);
         $this->assertSame('{"hello": "world"}', $inboxMsg->rawPayload);
     }
 
@@ -22,10 +24,12 @@ class InboxMessageTest extends TestCase
     {
         $inboxMsg = InboxMessage::make((object) [
             'id' => 1000,
+            'external_id' => 'fake-id',
             'payload' => null,
         ]);
 
         $this->assertSame(1000, $inboxMsg->id);
+        $this->assertSame('fake-id', $inboxMsg->externalId);
         $this->assertSame('{}', $inboxMsg->rawPayload);
     }
 
@@ -33,6 +37,7 @@ class InboxMessageTest extends TestCase
     {
         $inboxMsg = InboxMessage::make((object) [
             'id' => 1000,
+            'external_id' => 'fake-id',
             'payload' => '{"hello": "world"}',
         ]);
 
@@ -46,6 +51,7 @@ class InboxMessageTest extends TestCase
         $inboxMsg = InboxMessage::make((object) [
             'id' => 1000,
             'payload' => null,
+            'external_id' => 'fake-id',
         ]);
 
         $this->assertSame([], $inboxMsg->getParsedPayload());


### PR DESCRIPTION
## Laravel 11

- No biggie changes, allow userland to install inbox for Laravel ^11
- Updated the build

## Logs improvement

Now if you run the inbox process with `--log=1`, it also prints the current msg that being handled (same as queue:work)

## `--max-processing-time=3600` option

Instead of keeping the process forever, ideally, we should stop the process after an amount of time and let the supervisor re-run it. This will ensure zero memory leaks & reliable process.

You can enter the numbers that you want, by default it is 3600 (1 hour). Note that option is accepting `seconds`  value
